### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
   
-  http://www.apache.org/licenses/LICENSE-2.0
+  https://www.apache.org/licenses/LICENSE-2.0
   
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
@@ -154,11 +154,11 @@
         <version>1.12</version>
         <configuration>
           <excludedLinks>
-            <value>http://github.com/</value>
-            <value>http://git.or.cz/</value>
+            <value>https://github.com/</value>
+            <value>https://git-scm.com/</value>
             <value>http://localhost:8080/</value>
-            <value>http://repo.fusesource.com/</value>
-            <value>http://search.twitter.com/</value>
+            <value>https://repo.fusesource.com/</value>
+            <value>https://search.twitter.com/</value>
             <value>http://www.chengin.com/</value>
           </excludedLinks>
         </configuration>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.chengin.com/ (404) could not be migrated:  
   ([https](https://www.chengin.com/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://repo.fusesource.com/ (404) migrated to:  
  https://repo.fusesource.com/ ([https](https://repo.fusesource.com/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://git.or.cz/ (302) migrated to:  
  https://git-scm.com/ ([https](https://git.or.cz/) result 200).
* http://github.com/ migrated to:  
  https://github.com/ ([https](https://github.com/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://search.twitter.com/ migrated to:  
  https://search.twitter.com/ ([https](https://search.twitter.com/) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/
* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance