### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   
   <modelVersion>4.0.0</modelVersion>
   
@@ -154,12 +154,12 @@
         <version>1.12</version>
         <configuration>
           <excludedLinks>
-            <value>http://github.com/</value>
-            <value>http://git.or.cz/</value>
+            <value>https://github.com/</value>
+            <value>https://git-scm.com/</value>
             <value>http://localhost:8080/</value>
-            <value>http://repo.fusesource.com/</value>
-            <value>http://search.twitter.com/</value>
-            <value>http://www.chengin.com/</value>
+            <value>https://repo.fusesource.com/</value>
+            <value>https://search.twitter.com/</value>
+            <value>https://www.chengin.com/</value>
           </excludedLinks>
         </configuration>
       </plugin>

--- a/src/WEB-INF/web.xml
+++ b/src/WEB-INF/web.xml
@@ -20,8 +20,8 @@
 -->
 
 <web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+	xmlns="http://java.sun.com/xml/ns/javaee" xmlns:web="https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
 	version="2.5">
 
   <display-name>Scalate Sample Local Wiki</display-name>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://repo.fusesource.com/ (404) with 1 occurrences migrated to:  
  https://repo.fusesource.com/ ([https](https://repo.fusesource.com/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://git.or.cz/ (302) with 1 occurrences migrated to:  
  https://git-scm.com/ ([https](https://git.or.cz/) result 200).
* http://github.com/ with 1 occurrences migrated to:  
  https://github.com/ ([https](https://github.com/) result 200).
* http://maven.apache.org/maven-v4_0_0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://search.twitter.com/ with 1 occurrences migrated to:  
  https://search.twitter.com/ ([https](https://search.twitter.com/) result 301).
* http://www.chengin.com/ with 1 occurrences migrated to:  
  https://www.chengin.com/ ([https](https://www.chengin.com/) result 301).
* http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd with 2 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd ([https](https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/xml/ns/javaee with 2 occurrences
* http://localhost:8080/ with 1 occurrences
* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 2 occurrences