### PR TITLE
URL Cleanup

### DIFF
--- a/ext/Website.scala
+++ b/ext/Website.scala
@@ -22,12 +22,12 @@ package
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
+ * @author <a href="https://hiramchirino.com">Hiram Chirino</a>
  */
 object Website {
   val project_name= "STOMP Specification"
   val project_description= "The Simple Text Oriented Messaging Protocol"
   val project_logo= "/images/project-logo.png"
   val project_keywords= "stomp,messaging,mom,middleware,specification"
-  val website_base_url= "http://stomp.github.com"
+  val website_base_url= "https://stomp.github.com"
 }

--- a/project/plugins/Plugins.scala
+++ b/project/plugins/Plugins.scala
@@ -20,7 +20,7 @@ import sbt._
 class Plugins(info: ProjectInfo) extends PluginDefinition(info) {
   
   // lazy val fusesource_snapshot_repo = "FuseSource Snapshots" at
-  //         "http://repo.fusesource.com/nexus/content/repositories/snapshots"
+  //         "https://repo.fusesource.com/nexus/content/repositories/snapshots"
 
   lazy val scalate_plugin = "org.fusesource.scalate" % "sbt-scalate-plugin" % "1.4.1"
   

--- a/readme.md
+++ b/readme.md
@@ -16,12 +16,12 @@ lasted released specification is located at:
 ## Website Generation
 
 This git repository generates the STOMP specification static website
-using either [Maven](http://maven.apache.org/download.html) or the
-[SBT](http://code.google.com/p/simple-build-tool/wiki/Setup) build tool.
+using either [Maven](https://maven.apache.org/download.html) or the
+[SBT](https://code.google.com/p/simple-build-tool/wiki/Setup) build tool.
 
 ### Building with Maven
 
-Once you have [Maven](http://maven.apache.org/download.html) installed,
+Once you have [Maven](https://maven.apache.org/download.html) installed,
 you can generate the website by running:
 
     mvn package
@@ -32,7 +32,7 @@ point your web browser at `target/sitegen/index.html`
 ### Building with SBT
 
 Once you have
-[SBT](http://code.google.com/p/simple-build-tool/wiki/Setup) installed,
+[SBT](https://code.google.com/p/simple-build-tool/wiki/Setup) installed,
 you can generate the website by running:
 
     sbt update

--- a/src/implementations.page
+++ b/src/implementations.page
@@ -30,7 +30,7 @@ The Simple Text Oriented Messaging Protocol
   The following is a list of the various STOMP 1.1 compliant message 
   servers.
 
-  * [Apache Apollo](http://activemq.apache.org/apollo) a redesigned version of 
+  * [Apache Apollo](https://activemq.apache.org/apollo) a redesigned version of 
     ActiveMQ.
 
   # STOMP 1.1 Servers
@@ -38,7 +38,7 @@ The Simple Text Oriented Messaging Protocol
   The following is a list of the various STOMP 1.1 compliant message 
   servers.
 
-  * [Apache Apollo](http://activemq.apache.org/apollo) a redesigned version of 
+  * [Apache Apollo](https://activemq.apache.org/apollo) a redesigned version of 
     ActiveMQ.
 
   # STOMP 1.1 Clients
@@ -52,7 +52,7 @@ table.clients
 
   - language("Perl")
     :markdown
-      * [Net::STOMP::Client](http://search.cpan.org/dist/Net-STOMP-Client/)
+      * [Net::STOMP::Client](https://search.cpan.org/dist/Net-STOMP-Client/)
         Perl module is available on CPAN 
         
   - language("Ruby on Rails")
@@ -70,7 +70,7 @@ table.clients
 
   - language("Python")
     :markdown
-      * [stomp.py](http://code.google.com/p/stomppy/)
+      * [stomp.py](https://code.google.com/p/stomppy/)
       * [stompest](https://github.com/nikipore/stompest)
 
 :markdown
@@ -79,35 +79,35 @@ table.clients
   The following is a list of the various STOMP 1.0 compliant message 
   servers.
 
-  * [Apache ActiveMQ](http://activemq.apache.org/) is considered by many to be
+  * [Apache ActiveMQ](https://activemq.apache.org/) is considered by many to be
     the STOMP 1.0 reference implementation.
 
-  * [Apache Apollo](http://activemq.apache.org/apollo) a redesigned version of 
+  * [Apache Apollo](https://activemq.apache.org/apollo) a redesigned version of 
     ActiveMQ.
 
-  * [CoilMQ](http://code.google.com/p/coilmq/) is a lightweight pure Python Stomp
+  * [CoilMQ](https://code.google.com/p/coilmq/) is a lightweight pure Python Stomp
     broker inspired by StompServer.
 
   * [Gozirra](http://www.germane-software.com/software/Java/Gozirra/) is a
     lightweight Java Stomp broker
 
-  * [HornetQ](http://www.jboss.org/hornetq) puts the buzz in messaging
+  * [HornetQ](https://www.jboss.org/hornetq) puts the buzz in messaging
 
-  * [MorbidQ](http://www.morbidq.com/) is a STOMP publish/subscribe server with absolutely 
+  * [MorbidQ](https://www.morbidq.com/) is a STOMP publish/subscribe server with absolutely 
     no potential to cluster. It supports publish/subscribe topics, and runs as a 
     single node.
 
-  * [RabbitMQ](http://www.rabbitmq.com/plugins.html#rabbitmq-stomp) an Erlang-based,
+  * [RabbitMQ](https://www.rabbitmq.com/plugins.html#rabbitmq-stomp) an Erlang-based,
     multi-protocol broker with full support for STOMP via a plugin.
 
   * [Sprinkle](http://www.thuswise.org/sprinkle/index.html) is written in Python 
     and runs on Unix type platforms.
 
-  * [StompConnect](http://stomp.codehaus.org/StompConnect) provides a bridge to
+  * [StompConnect](https://stomp.codehaus.org/StompConnect) provides a bridge to
     any other JMS provider. This means that all major commercial and open source
     message brokers can be used with Stomp!
 
-  * [StompServer](http://stompserver.rubyforge.org/) is a lightweight pure Ruby
+  * [StompServer](https://stompserver.rubyforge.org/) is a lightweight pure Ruby
     Stomp server
 
   # STOMP 1.0 Clients
@@ -121,24 +121,24 @@ table.clients
     
   - language("C")
     :markdown
-      * [libstomp](http://stomp.codehaus.org/C) is an APR based c library
+      * [libstomp](https://stomp.codehaus.org/C) is an APR based c library
       
   - language("Dynamic C")
     :markdown
-      * [dstomp](http://code.google.com/p/dstomp/) is a STOMP client library
+      * [dstomp](https://code.google.com/p/dstomp/) is a STOMP client library
         written in Dynamic C for Rabbit
 
   - language("C++")
     :markdown
-      * [Apache CMS](http://activemq.apache.org/cms/): is a JMS-like API for C++.
+      * [Apache CMS](https://activemq.apache.org/cms/): is a JMS-like API for C++.
 
   - language("C# and .Net")
     :markdown
-      * [Apache NMS](http://activemq.apache.org/nms/): is a JMS-like API for .Net
+      * [Apache NMS](https://activemq.apache.org/nms/): is a JMS-like API for .Net
 
   - language("Delphi and FreePascal")
     :markdown
-      * [delphistompclient](http://code.google.com/p/delphistompclient/): is a
+      * [delphistompclient](https://code.google.com/p/delphistompclient/): is a
         STOMP client for Embarcadero Delphi and FreePascal. [more
         info](http://www.danieleteti.it/?page_id=214)
 
@@ -149,14 +149,14 @@ table.clients
 
   - language("Flash")
     :markdown
-      * [as3-stomp](http://code.google.com/p/as3-stomp/) is an actionscript 3
+      * [as3-stomp](https://code.google.com/p/as3-stomp/) is an actionscript 3
         implementation of the STOMP protocol. [more
-        info](http://flexonrails.net/?cat=26)
+        info](https://flexonrails.net/?cat=26)
 
   - language("haXe")
     :markdown
-      * [hxStomp](hxstomp|http://code.google.com/p/hxstomp/) is a TCP socket-based
-        Stomp protocol client library written for the [Haxe](http://www.haxe.org)
+      * [hxStomp](hxstomp|https://code.google.com/p/hxstomp/) is a TCP socket-based
+        Stomp protocol client library written for the [Haxe](https://www.haxe.org)
         language.
 
   - language("Java")
@@ -167,47 +167,47 @@ table.clients
     :markdown
       * [objc-stomp](https://github.com/juretta/objc-stomp) is a simple STOMP
         client based on AsynSocket. [more
-        info](http://dev.coravy.com/wiki/display/OpenSource/Stomp+client+for+Objective-C)
+        info](http://coravy.com/wiki/display/OpenSource/Stomp+client+for+Objective-C)
 
   - language("Perl")
     :markdown
-      * [Net::STOMP::Client](http://search.cpan.org/dist/Net-STOMP-Client/)
+      * [Net::STOMP::Client](https://search.cpan.org/dist/Net-STOMP-Client/)
         Perl module is available on CPAN 
-      * [Net::Stomp](http://search.cpan.org/dist/Net-Stomp/)
+      * [Net::Stomp](https://search.cpan.org/dist/Net-Stomp/)
         Perl module is available on CPAN
-      * [AnyEvent::STOMP](http://search.cpan.org/dist/AnyEvent-STOMP/)
+      * [AnyEvent::STOMP](https://search.cpan.org/dist/AnyEvent-STOMP/)
         Perl module is available on CPAN
-      * [POE::Component::Client::Stomp](http://search.cpan.org/dist/POE-Component-Client-Stomp/)
+      * [POE::Component::Client::Stomp](https://search.cpan.org/dist/POE-Component-Client-Stomp/)
         Perl module is available on CPAN
 
   - language("PHP")
     :markdown
       * [stomp](http://www.php.net/manual/en/book.stomp.php) official php extension
-        available at [pecl](http://pecl.php.net/package/stomp)
-      * [stomp-php](http://stomp.fusesource.org/documentation/php/book.html) is the
-        [FuseSource](http://fusesource.org) PHP client implementation
-      * [Zend\_Queue\_Stomp](http://framework.zend.com/manual/en/zend.queue.stomp.html)
+        available at [pecl](https://pecl.php.net/package/stomp)
+      * [stomp-php](https://stomp.fusesource.org/documentation/php/book.html) is the
+        [FuseSource](https://fusesource.org) PHP client implementation
+      * [Zend\_Queue\_Stomp](https://framework.zend.com/manual/en/zend.queue.stomp.html)
         for Zend PHP clients
-      * [simplisticstompclient](http://code.google.com/p/simplisticstompclient/) is
+      * [simplisticstompclient](https://code.google.com/p/simplisticstompclient/) is
         a simpler STOMP client for PHP
 
   - language("Pike")
     :markdown
-      * [Public.Protocols.Stomp](http://modules.gotpike.org/module_info.html?module_id=24)
+      * [Public.Protocols.Stomp](http://modules.gotpike.org/(SessionID=5a96cd922aa22b42702dc46c695ed479)/module_info.html?module_id=24)
 
   - language("Python")
     :markdown
-      * [stompy](http://www.makemyshow.com/stompy.shtml)
-      * [stomp.py](http://code.google.com/p/stomppy/)
-      * [pyactivemq](http://code.google.com/p/pyactivemq/)
-      * [stomper](http://code.google.com/p/stomper/)
+      * [stompy](https://www.makemyshow.com/stompy.shtml)
+      * [stomp.py](https://code.google.com/p/stomppy/)
+      * [pyactivemq](https://code.google.com/p/pyactivemq/)
+      * [stomper](https://code.google.com/p/stomper/)
       * [stompest](https://github.com/nikipore/stompest)
 
   - language("Ruby on Rails")
     :markdown
       * [stomp gem](https://rubygems.org/gems/stomp) The canonical stomp 
         repository is available at https://github.com/stompgem/stomp
-      * [activemessaging](http://code.google.com/p/activemessaging/) s an attempt
+      * [activemessaging](https://code.google.com/p/activemessaging/) s an attempt
         to bring the simplicity and elegance of Rails development to the world of
         messaging
       * [onstomp gem](https://rubygems.org/gems/onstomp) it's source is at

--- a/src/index.page
+++ b/src/index.page
@@ -57,8 +57,8 @@ The Simple Text Oriented Messaging Protocol
   :markdown
     If your are a STOMP implementer, we would we love you to join the specification discussions.
 
-    The main mailing list is hosted at the [stomp-spec google group](http://groups.google.com/group/stomp-spec).
+    The main mailing list is hosted at the [stomp-spec google group](https://groups.google.com/group/stomp-spec).
 
-    * [http://groups.google.com/group/stomp-spec](http://groups.google.com/group/stomp-spec)
+    * [https://groups.google.com/group/stomp-spec](https://groups.google.com/group/stomp-spec)
     
     Be aware that to reduce spam your first post will be moderated through; so please be patient. (Unfortunately we get a lot of spam)

--- a/src/stomp-specification-1.0.md
+++ b/src/stomp-specification-1.0.md
@@ -59,7 +59,7 @@ it does not, in fact, specify any such thing. Destination names are simply
 strings which are mapped to some form of destination on the server - how the
 server translates these is left to the server implementation. See [this note
 on mapping destination strings to JMS
-Destinations](http://activemq.apache.org/stomp.html) for more detail.
+Destinations](https://activemq.apache.org/stomp.html) for more detail.
 
 SEND supports a *transaction* header which allows for transaction sends.
 
@@ -92,7 +92,7 @@ the header is not included) and *client*.
 The body of the SUBSCRIBE command is ignored.
 
 Stomp brokers may support the *selector* header which allows you to specify
-an [SQL 92 selector](http://activemq.apache.org/selectors.html) on the
+an [SQL 92 selector](https://activemq.apache.org/selectors.html) on the
 message headers which acts as a filter for content based routing.
 
 You can also specify an *id* header which can then later on be used to
@@ -101,8 +101,8 @@ subscriptions using selectors with the same destination. If an *id* header is
 supplied then Stomp brokers should append a *subscription* header to any
 MESSAGE commands which are sent to the client so that the client knows which
 subscription the message relates to. If using
-[Wildcards](http://activemq.apache.org/wildcards.html) and
-[selectors](http://activemq.apache.org/selectors.html) this can help clients
+[Wildcards](https://activemq.apache.org/wildcards.html) and
+[selectors](https://activemq.apache.org/selectors.html) this can help clients
 figure out what subscription caused the message to be created.
 
 <h3 id="frame-UNSUBSCRIBE">UNSUBSCRIBE</h3>
@@ -324,4 +324,4 @@ We will use the augmented Backus-Naur Form (BNF) used in the HTTP/1.1
     binary-content      = 1*OCTECT
 
 This spec is licensed under the [Creative Commons Attribution
-v2.5](http://creativecommons.org/licenses/by/2.5/)
+v2.5](https://creativecommons.org/licenses/by/2.5/)

--- a/src/stomp-specification-1.1.md
+++ b/src/stomp-specification-1.1.md
@@ -741,7 +741,7 @@ direction, if heart-beats are expected every `<n>` milliseconds:
 
 A STOMP session can be more formally described using the
 Backus-Naur Form (BNF) grammar used in HTTP/1.1
-[rfc2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.1).
+[rfc2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.1).
 
     LF                  = <US-ASCII new line (line feed) (octet 10)>
     OCTET               = <any 8-bit sequence of data>
@@ -782,5 +782,5 @@ Backus-Naur Form (BNF) grammar used in HTTP/1.1
 ## License
 
 This specification is licensed under the
-[Creative Commons Attribution v2.5](http://creativecommons.org/licenses/by/2.5/)
+[Creative Commons Attribution v2.5](https://creativecommons.org/licenses/by/2.5/)
 license.

--- a/src/stomp-specification-1.2.md
+++ b/src/stomp-specification-1.2.md
@@ -104,7 +104,7 @@ documentation for the implementation specific details of these features.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
+interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
 Implementations may impose implementation-specific limits on unconstrained
 inputs, e.g. to prevent denial of service attacks, to guard against running
@@ -852,7 +852,7 @@ details.
 
 A STOMP session can be more formally described using the
 Backus-Naur Form (BNF) grammar used in HTTP/1.1
-[RFC 2616](http://tools.ietf.org/html/rfc2616#section-2.1).
+[RFC 2616](https://tools.ietf.org/html/rfc2616#section-2.1).
 
     NULL                = <US-ASCII null (octet 0)>
     LF                  = <US-ASCII line feed (aka newline) (octet 10)>
@@ -895,5 +895,5 @@ Backus-Naur Form (BNF) grammar used in HTTP/1.1
 ## License
 
 This specification is licensed under the
-[Creative Commons Attribution v3.0](http://creativecommons.org/licenses/by/3.0/)
+[Creative Commons Attribution v3.0](https://creativecommons.org/licenses/by/3.0/)
 license.

--- a/src/stomp-specification-2.0.md
+++ b/src/stomp-specification-2.0.md
@@ -732,7 +732,7 @@ direction, if heart-beats are expected every `<n>` milliseconds:
 
 A STOMP session can be more formally described using the
 Backus-Naur Form (BNF) grammar used in HTTP/1.1
-[rfc2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.1).
+[rfc2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.1).
 
     LF                  = <US-ASCII new line (line feed) (octet 10)>
     OCTET               = <any 8-bit sequence of data>
@@ -773,5 +773,5 @@ Backus-Naur Form (BNF) grammar used in HTTP/1.1
 ## License
 
 This specification is licensed under the
-[Creative Commons Attribution v2.5](http://creativecommons.org/licenses/by/2.5/)
+[Creative Commons Attribution v2.5](https://creativecommons.org/licenses/by/2.5/)
 license.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.danieleteti.it/?page_id=214 (200) with 1 occurrences could not be migrated:  
   ([https](https://www.danieleteti.it/?page_id=214) result SSLProtocolException).
* http://www.germane-software.com/software/Java/Gozirra/ (200) with 2 occurrences could not be migrated:  
   ([https](https://www.germane-software.com/software/Java/Gozirra/) result SSLHandshakeException).
* http://www.hccp.org/erlang-stomp-client.html (200) with 1 occurrences could not be migrated:  
   ([https](https://www.hccp.org/erlang-stomp-client.html) result ConnectTimeoutException).
* http://www.php.net/manual/en/book.stomp.php (200) with 1 occurrences could not be migrated:  
   ([https](https://www.php.net/manual/en/book.stomp.php) result NotSslRecordException).
* http://dev.coravy.com/wiki/display/OpenSource/Stomp+client+for+Objective-C (301) with 1 occurrences could not be migrated:  
   ([https](https://dev.coravy.com/wiki/display/OpenSource/Stomp+client+for+Objective-C) result SSLHandshakeException).
* http://modules.gotpike.org/module_info.html?module_id=24 (302) with 1 occurrences could not be migrated:  
   ([https](https://modules.gotpike.org/module_info.html?module_id=24) result SSLHandshakeException).
* http://www.thuswise.org/sprinkle/index.html (404) with 1 occurrences could not be migrated:  
   ([https](https://www.thuswise.org/sprinkle/index.html) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://fusesource.org (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://fusesource.org ([https](https://fusesource.org) result ConnectTimeoutException).
* http://stomp.fusesource.org/documentation/php/book.html (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://stomp.fusesource.org/documentation/php/book.html ([https](https://stomp.fusesource.org/documentation/php/book.html) result ConnectTimeoutException).
* http://stompserver.rubyforge.org/ (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://stompserver.rubyforge.org/ ([https](https://stompserver.rubyforge.org/) result ConnectTimeoutException).
* http://www.makemyshow.com/stompy.shtml (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.makemyshow.com/stompy.shtml ([https](https://www.makemyshow.com/stompy.shtml) result ConnectTimeoutException).
* http://pecl.php.net/package/stomp (ReadTimeoutException) with 1 occurrences migrated to:  
  https://pecl.php.net/package/stomp ([https](https://pecl.php.net/package/stomp) result ReadTimeoutException).
* http://stomp.codehaus.org/C (UnknownHostException) with 1 occurrences migrated to:  
  https://stomp.codehaus.org/C ([https](https://stomp.codehaus.org/C) result UnknownHostException).
* http://stomp.codehaus.org/StompConnect (UnknownHostException) with 1 occurrences migrated to:  
  https://stomp.codehaus.org/StompConnect ([https](https://stomp.codehaus.org/StompConnect) result UnknownHostException).
* http://flexonrails.net/?cat=26 (403) with 1 occurrences migrated to:  
  https://flexonrails.net/?cat=26 ([https](https://flexonrails.net/?cat=26) result 403).
* http://framework.zend.com/manual/en/zend.queue.stomp.html (301) with 1 occurrences migrated to:  
  https://framework.zend.com/manual/en/zend.queue.stomp.html ([https](https://framework.zend.com/manual/en/zend.queue.stomp.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://activemq.apache.org/ with 1 occurrences migrated to:  
  https://activemq.apache.org/ ([https](https://activemq.apache.org/) result 200).
* http://activemq.apache.org/cms/ with 1 occurrences migrated to:  
  https://activemq.apache.org/cms/ ([https](https://activemq.apache.org/cms/) result 200).
* http://activemq.apache.org/nms/ with 1 occurrences migrated to:  
  https://activemq.apache.org/nms/ ([https](https://activemq.apache.org/nms/) result 200).
* http://activemq.apache.org/selectors.html with 2 occurrences migrated to:  
  https://activemq.apache.org/selectors.html ([https](https://activemq.apache.org/selectors.html) result 200).
* http://activemq.apache.org/stomp.html with 1 occurrences migrated to:  
  https://activemq.apache.org/stomp.html ([https](https://activemq.apache.org/stomp.html) result 200).
* http://activemq.apache.org/wildcards.html with 1 occurrences migrated to:  
  https://activemq.apache.org/wildcards.html ([https](https://activemq.apache.org/wildcards.html) result 200).
* http://creativecommons.org/licenses/by/2.5/ with 3 occurrences migrated to:  
  https://creativecommons.org/licenses/by/2.5/ ([https](https://creativecommons.org/licenses/by/2.5/) result 200).
* http://creativecommons.org/licenses/by/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by/3.0/ ([https](https://creativecommons.org/licenses/by/3.0/) result 200).
* http://tools.ietf.org/html/rfc2119 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2119 ([https](https://tools.ietf.org/html/rfc2119) result 200).
* http://tools.ietf.org/html/rfc2616 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2616 ([https](https://tools.ietf.org/html/rfc2616) result 200).
* http://www.rabbitmq.com/plugins.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/plugins.html ([https](https://www.rabbitmq.com/plugins.html) result 200).
* http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html with 2 occurrences migrated to:  
  https://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html ([https](https://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html) result 200).
* http://activemq.apache.org/apollo with 3 occurrences migrated to:  
  https://activemq.apache.org/apollo ([https](https://activemq.apache.org/apollo) result 301).
* http://code.google.com/p/activemessaging/ with 1 occurrences migrated to:  
  https://code.google.com/p/activemessaging/ ([https](https://code.google.com/p/activemessaging/) result 301).
* http://code.google.com/p/as3-stomp/ with 1 occurrences migrated to:  
  https://code.google.com/p/as3-stomp/ ([https](https://code.google.com/p/as3-stomp/) result 301).
* http://code.google.com/p/coilmq/ with 1 occurrences migrated to:  
  https://code.google.com/p/coilmq/ ([https](https://code.google.com/p/coilmq/) result 301).
* http://code.google.com/p/delphistompclient/ with 1 occurrences migrated to:  
  https://code.google.com/p/delphistompclient/ ([https](https://code.google.com/p/delphistompclient/) result 301).
* http://code.google.com/p/dstomp/ with 1 occurrences migrated to:  
  https://code.google.com/p/dstomp/ ([https](https://code.google.com/p/dstomp/) result 301).
* http://code.google.com/p/hxstomp/ with 1 occurrences migrated to:  
  https://code.google.com/p/hxstomp/ ([https](https://code.google.com/p/hxstomp/) result 301).
* http://code.google.com/p/pyactivemq/ with 1 occurrences migrated to:  
  https://code.google.com/p/pyactivemq/ ([https](https://code.google.com/p/pyactivemq/) result 301).
* http://code.google.com/p/simple-build-tool/wiki/Setup with 2 occurrences migrated to:  
  https://code.google.com/p/simple-build-tool/wiki/Setup ([https](https://code.google.com/p/simple-build-tool/wiki/Setup) result 301).
* http://code.google.com/p/simplisticstompclient/ with 1 occurrences migrated to:  
  https://code.google.com/p/simplisticstompclient/ ([https](https://code.google.com/p/simplisticstompclient/) result 301).
* http://code.google.com/p/stomper/ with 1 occurrences migrated to:  
  https://code.google.com/p/stomper/ ([https](https://code.google.com/p/stomper/) result 301).
* http://code.google.com/p/stomppy/ with 2 occurrences migrated to:  
  https://code.google.com/p/stomppy/ ([https](https://code.google.com/p/stomppy/) result 301).
* http://groups.google.com/group/stomp-spec with 3 occurrences migrated to:  
  https://groups.google.com/group/stomp-spec ([https](https://groups.google.com/group/stomp-spec) result 301).
* http://maven.apache.org/download.html with 2 occurrences migrated to:  
  https://maven.apache.org/download.html ([https](https://maven.apache.org/download.html) result 301).
* http://repo.fusesource.com/nexus/content/repositories/snapshots with 1 occurrences migrated to:  
  https://repo.fusesource.com/nexus/content/repositories/snapshots ([https](https://repo.fusesource.com/nexus/content/repositories/snapshots) result 301).
* http://search.cpan.org/dist/AnyEvent-STOMP/ with 1 occurrences migrated to:  
  https://search.cpan.org/dist/AnyEvent-STOMP/ ([https](https://search.cpan.org/dist/AnyEvent-STOMP/) result 301).
* http://search.cpan.org/dist/Net-STOMP-Client/ with 2 occurrences migrated to:  
  https://search.cpan.org/dist/Net-STOMP-Client/ ([https](https://search.cpan.org/dist/Net-STOMP-Client/) result 301).
* http://search.cpan.org/dist/Net-Stomp/ with 1 occurrences migrated to:  
  https://search.cpan.org/dist/Net-Stomp/ ([https](https://search.cpan.org/dist/Net-Stomp/) result 301).
* http://search.cpan.org/dist/POE-Component-Client-Stomp/ with 1 occurrences migrated to:  
  https://search.cpan.org/dist/POE-Component-Client-Stomp/ ([https](https://search.cpan.org/dist/POE-Component-Client-Stomp/) result 301).
* http://stomp.github.com with 1 occurrences migrated to:  
  https://stomp.github.com ([https](https://stomp.github.com) result 301).
* http://www.haxe.org with 1 occurrences migrated to:  
  https://www.haxe.org ([https](https://www.haxe.org) result 301).
* http://www.jboss.org/hornetq with 1 occurrences migrated to:  
  https://www.jboss.org/hornetq ([https](https://www.jboss.org/hornetq) result 301).
* http://www.morbidq.com/ with 1 occurrences migrated to:  
  https://www.morbidq.com/ ([https](https://www.morbidq.com/) result 301).
* http://hiramchirino.com with 1 occurrences migrated to:  
  https://hiramchirino.com ([https](https://hiramchirino.com) result 302).